### PR TITLE
feat: #4 로컬캐시를 이용한 피쳐 토글 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
 
 	// lombok
 	compileOnly("org.projectlombok:lombok")
@@ -34,6 +35,9 @@ dependencies {
 	// h2
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("org.mariadb.jdbc:mariadb-java-client:3.3.3")
+
+	//swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/feature/toggle/infra/cache/CacheConfig.java
+++ b/src/main/java/com/feature/toggle/infra/cache/CacheConfig.java
@@ -1,0 +1,9 @@
+package com.feature.toggle.infra.cache;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+}

--- a/src/main/java/com/feature/toggle/infra/oas/OasConfig.java
+++ b/src/main/java/com/feature/toggle/infra/oas/OasConfig.java
@@ -1,0 +1,15 @@
+package com.feature.toggle.infra.oas;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OasConfig {
+    @Bean
+    public OpenAPI apiConfig() {
+        return new OpenAPI()
+                .info(new Info().title("FEATURE TOGGLE API"));
+    }
+}

--- a/src/main/java/com/feature/toggle/simplelocalcahce/controller/SimpleCacheToggleController.java
+++ b/src/main/java/com/feature/toggle/simplelocalcahce/controller/SimpleCacheToggleController.java
@@ -1,0 +1,28 @@
+package com.feature.toggle.simplelocalcahce.controller;
+
+import com.feature.toggle.simplelocalcahce.service.SimpleCacheToggleService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/simple/cache")
+@Tag(name = "로컬 캐시 토글", description = "로컬 캐시를 이용한 토글 관련 API 입니다.")
+public class SimpleCacheToggleController {
+    private final SimpleCacheToggleService simpleCacheToggleService;
+
+    @GetMapping
+    public void get(@RequestParam(defaultValue = "SIMPLE-CACHE-TOGGLE") final String toggleId) {
+        simpleCacheToggleService.logic(toggleId);
+    }
+
+    @PutMapping
+    public void changeUseYn(@RequestParam(defaultValue = "SIMPLE-CACHE-TOGGLE") final String toggleId) {
+        simpleCacheToggleService.changeUseYn(toggleId);
+    }
+}

--- a/src/main/java/com/feature/toggle/simplelocalcahce/service/SimpleCacheToggleService.java
+++ b/src/main/java/com/feature/toggle/simplelocalcahce/service/SimpleCacheToggleService.java
@@ -1,0 +1,30 @@
+package com.feature.toggle.simplelocalcahce.service;
+
+import com.feature.toggle.simplelocalcahce.toggle.SimpleCacheToggleFinder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SimpleCacheToggleService {
+    private final SimpleCacheToggleFinder simpleCacheToggleFinder;
+
+    @Transactional(readOnly = true)
+    public void logic(final String toggleId) {
+        if (simpleCacheToggleFinder.isActive(toggleId)) {
+            log.info("TOGGLE STATUS IS ACTIVE ! ! !");
+
+            return;
+        }
+
+        log.info("TOGGLE STATUS IS NON-ACTIVE ! ! !");
+    }
+
+    @Transactional
+    public void changeUseYn(final String toggleId) {
+        simpleCacheToggleFinder.changeUseYn(toggleId);
+    }
+}

--- a/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggle.java
+++ b/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggle.java
@@ -17,9 +17,7 @@ import org.hibernate.annotations.Comment;
 
 @Getter
 @Entity
-@Builder
 @Table(name = "SIMPLE_CACHE_TOGGLE_INFO")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SimpleCacheToggle {
     @Id
@@ -39,6 +37,14 @@ public class SimpleCacheToggle {
     @Column(name = "USE_YN")
     @Convert(converter = BooleanYnConverter.class)
     private boolean useYn;
+
+    @Builder
+    protected SimpleCacheToggle(Long id, String toggleId, String description, boolean useYn) {
+        this.id = id;
+        this.toggleId = toggleId;
+        this.description = description;
+        this.useYn = useYn;
+    }
 
     public void changeUseYn() {
         if (useYn) {

--- a/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggle.java
+++ b/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggle.java
@@ -1,0 +1,52 @@
+package com.feature.toggle.simplelocalcahce.toggle;
+
+import com.feature.toggle.infra.orm.BooleanYnConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "SIMPLE_CACHE_TOGGLE_INFO")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SimpleCacheToggle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Comment("토글 ID")
+    @Column(name = "TOGGLE_ID", length = 32)
+    private String toggleId;
+
+    @Comment("설명")
+    @Column(name = "DESCRIPTION", length = 128)
+    private String description;
+
+    @Comment("사용 여부")
+    @Column(name = "USE_YN")
+    @Convert(converter = BooleanYnConverter.class)
+    private boolean useYn;
+
+    public void changeUseYn() {
+        if (useYn) {
+            this.useYn = false;
+
+            return;
+        }
+
+        this.useYn = true;
+    }
+}

--- a/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleFinder.java
+++ b/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleFinder.java
@@ -1,0 +1,32 @@
+package com.feature.toggle.simplelocalcahce.toggle;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SimpleCacheToggleFinder {
+    private final SimpleCacheToggleRepository simpleCacheToggleRepository;
+
+    @Transactional(readOnly = true)
+    @Cacheable(value = "toggles-active", key = "#toggleId")
+    public boolean isActive(final String toggleId) {
+        return simpleCacheToggleRepository.findByToggleId(toggleId)
+                .map(SimpleCacheToggle::isUseYn)
+                .orElse(false);
+    }
+
+    @Transactional
+    @CacheEvict(value = "toggles-active", key = "#toggleId")
+    public void changeUseYn(final String toggleId) {
+        SimpleCacheToggle toggle = simpleCacheToggleRepository.findByToggleId(toggleId)
+                .orElseThrow(RuntimeException::new);
+
+        toggle.changeUseYn();
+    }
+}

--- a/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleRepository.java
+++ b/src/main/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleRepository.java
@@ -1,0 +1,9 @@
+package com.feature.toggle.simplelocalcahce.toggle;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SimpleCacheToggleRepository extends JpaRepository<SimpleCacheToggle, Long> {
+    Optional<SimpleCacheToggle> findByToggleId(String toggleId);
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -7,3 +7,6 @@ values ('TOGGLE-ONE', '유효기간이 지났지만 사용여부는 Y인 토글'
        ('TOGGLE-TWO', '유효기간이 지나고 사용하지 않는 토글', '2024-01-01 00:00:00', '2024-01-01 23:59:59', 'N'),
        ('TOGGLE-THREE', '유효기간에 해당하면서 사용 중인 토글', '2024-08-18 00:00:00', '2024-08-18 23:59:59', 'Y'),
        ('TOGGLE-FOUR', '유효기간이지만 사용하지 않는 토글', '2024-08-18 00:00:00', '2024-08-18 23:59:59', 'N');
+
+insert into SIMPLE_CACHE_TOGGLE_INFO (TOGGLE_ID, DESCRIPTION, USE_YN)
+values ('SIMPLE-CACHE-TOGGLE', '심플 토글입니다.', 'Y');

--- a/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleFinderTest.java
+++ b/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleFinderTest.java
@@ -1,0 +1,54 @@
+package com.feature.toggle.simplelocalcahce.toggle;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class SimpleCacheToggleFinderTest {
+    @Autowired
+    private SimpleCacheToggleFinder simpleCacheToggleFinder;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    final String toggleName = "toggles-active";
+
+    @Nested
+    @DisplayName("토글을 조회할 때,")
+    class isActive {
+        @Test
+        @DisplayName("조회한 이력이 없을 경우 캐시에 저장되지 않는다.")
+        void notSaveCache() {
+            //given
+            final String toggleId = "SIMPLE-CACHE-TOGGLE";
+
+            //when & then
+            assertThrows(NullPointerException.class, () -> cacheManager.getCache(toggleName).get(toggleId).get());
+        }
+
+        @Test
+        @DisplayName("한 번 조회하면 캐시에 값이 저장 된다.")
+        void usedCached() {
+            //given
+            final String toggleId = "SIMPLE-CACHE-TOGGLE";
+
+            simpleCacheToggleFinder.isActive(toggleId);
+
+            //when
+            final boolean result = (Boolean) Objects.requireNonNull(cacheManager.getCache(toggleName).get(toggleId)).get();
+
+            //then
+            assertThat(result).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleTest.java
+++ b/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleTest.java
@@ -15,7 +15,7 @@ class SimpleCacheToggleTest {
         void changeFalse() {
             //given
             final boolean request = true;
-            final SimpleCacheToggle toggle = simpleCacheToggle을_생성합니다(request);
+            final SimpleCacheToggle toggle = SimpleCacheToggleTestFixture.flag를받아_객체를_생성합니다(request);
 
             //when
             toggle.changeUseYn();
@@ -29,7 +29,7 @@ class SimpleCacheToggleTest {
         void changeTrue() {
             //given
             final boolean request = false;
-            final SimpleCacheToggle toggle = simpleCacheToggle을_생성합니다(request);
+            final SimpleCacheToggle toggle = SimpleCacheToggleTestFixture.flag를받아_객체를_생성합니다(request);
 
             //when
             toggle.changeUseYn();
@@ -37,12 +37,5 @@ class SimpleCacheToggleTest {
             //then
             assertThat(toggle.isUseYn()).isTrue();
         }
-    }
-
-    private SimpleCacheToggle simpleCacheToggle을_생성합니다(boolean flag) {
-        return SimpleCacheToggle.builder()
-                .id(1L)
-                .useYn(flag)
-                .build();
     }
 }

--- a/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleTest.java
+++ b/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleTest.java
@@ -1,0 +1,48 @@
+package com.feature.toggle.simplelocalcahce.toggle;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleCacheToggleTest {
+    @Nested
+    @DisplayName("사용여부를 바꿀 때,")
+    class changeYn {
+        @Test
+        @DisplayName("true이면 false를 반환합니다.")
+        void changeFalse() {
+            //given
+            final boolean request = true;
+            final SimpleCacheToggle toggle = simpleCacheToggle을_생성합니다(request);
+
+            //when
+            toggle.changeUseYn();
+
+            //then
+            assertThat(toggle.isUseYn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("false이면 true를 반환합니다.")
+        void changeTrue() {
+            //given
+            final boolean request = false;
+            final SimpleCacheToggle toggle = simpleCacheToggle을_생성합니다(request);
+
+            //when
+            toggle.changeUseYn();
+
+            //then
+            assertThat(toggle.isUseYn()).isTrue();
+        }
+    }
+
+    private SimpleCacheToggle simpleCacheToggle을_생성합니다(boolean flag) {
+        return SimpleCacheToggle.builder()
+                .id(1L)
+                .useYn(flag)
+                .build();
+    }
+}

--- a/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleTestFixture.java
+++ b/src/test/java/com/feature/toggle/simplelocalcahce/toggle/SimpleCacheToggleTestFixture.java
@@ -1,0 +1,10 @@
+package com.feature.toggle.simplelocalcahce.toggle;
+
+class SimpleCacheToggleTestFixture {
+    public static SimpleCacheToggle flag를받아_객체를_생성합니다(boolean flag) {
+        return SimpleCacheToggle.builder()
+                .id(1L)
+                .useYn(flag)
+                .build();
+    }
+}


### PR DESCRIPTION
로컬캐시를 이용하여 피쳐 토글을 이용할 수 있도록 만들어 보았습니다.

기존 심플토글의 경우 모든 인원이 해당 토글을 이용하게 되면 모두 DB에서 조회를 하게 되었는데,
자주 사용되는 경우는 로컬 캐시를 이용해서 처리할 수 있도록 만들었습니다.