### PR TITLE
feat: map + 스케줄러 토글 생성

### DIFF
--- a/src/main/java/com/feature/toggle/infra/scheduled/SchedulingConfig.java
+++ b/src/main/java/com/feature/toggle/infra/scheduled/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.feature.toggle.infra.scheduled;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig {
+}

--- a/src/main/java/com/feature/toggle/mapchache/MapCacheToggle.java
+++ b/src/main/java/com/feature/toggle/mapchache/MapCacheToggle.java
@@ -1,0 +1,49 @@
+package com.feature.toggle.mapchache;
+
+import com.feature.toggle.infra.orm.BooleanYnConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@Table(name = "MAP_CACHE_TOGGLE_INFO")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapCacheToggle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Comment("토글 ID")
+    @Column(name = "TOGGLE_ID", length = 32)
+    private String toggleId;
+
+    @Comment("설명")
+    @Column(name = "DESCRIPTION", length = 128)
+    private String description;
+
+    @Comment("사용 여부")
+    @Column(name = "USE_YN")
+    @Convert(converter = BooleanYnConverter.class)
+    private boolean useYn;
+
+    public void changeUseYn() {
+        if (useYn) {
+            this.useYn = false;
+
+            return;
+        }
+
+        this.useYn = true;
+    }
+}

--- a/src/main/java/com/feature/toggle/mapchache/MapCacheToggleFinder.java
+++ b/src/main/java/com/feature/toggle/mapchache/MapCacheToggleFinder.java
@@ -1,0 +1,31 @@
+package com.feature.toggle.mapchache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MapCacheToggleFinder {
+
+    private final MapToggleSnapshot snapshot;
+    private final MapCacheToggleRepository cacheToggleRepository;
+
+    public boolean isActive(final String toggleId) {
+        return snapshot.getOrDefault(toggleId);
+    }
+
+    public void replaceAll(final Map<String, Boolean> newValues) {
+        snapshot.replaceAll(newValues);
+    }
+
+    @Transactional
+    public void update(final String toggleId) {
+        final MapCacheToggle toggle = cacheToggleRepository.findByToggleId(toggleId)
+                .orElseThrow();
+
+        toggle.changeUseYn();
+    }
+}

--- a/src/main/java/com/feature/toggle/mapchache/MapCacheToggleRefresher.java
+++ b/src/main/java/com/feature/toggle/mapchache/MapCacheToggleRefresher.java
@@ -1,0 +1,31 @@
+package com.feature.toggle.mapchache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MapCacheToggleRefresher {
+
+    private final MapCacheToggleRepository repository;
+    private final MapCacheToggleFinder finder;
+
+    @Scheduled(initialDelayString = "0", fixedDelayString = "${toggle.cache.refresh-delay-ms:10000}")
+    @Transactional(readOnly = true)
+    public void refresh() {
+        final Map<String, Boolean> values = repository.findAll().stream()
+                .collect(Collectors.toMap(
+                        MapCacheToggle::getToggleId,
+                        MapCacheToggle::isUseYn
+                ));
+
+        finder.replaceAll(values);
+    }
+}

--- a/src/main/java/com/feature/toggle/mapchache/MapCacheToggleRepository.java
+++ b/src/main/java/com/feature/toggle/mapchache/MapCacheToggleRepository.java
@@ -1,0 +1,9 @@
+package com.feature.toggle.mapchache;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MapCacheToggleRepository extends JpaRepository<MapCacheToggle, Long> {
+    Optional<MapCacheToggle> findByToggleId(String toggleId);
+}

--- a/src/main/java/com/feature/toggle/mapchache/MapToggleSnapshot.java
+++ b/src/main/java/com/feature/toggle/mapchache/MapToggleSnapshot.java
@@ -1,0 +1,20 @@
+package com.feature.toggle.mapchache;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Component
+public class MapToggleSnapshot {
+
+    private volatile Map<String, Boolean> ref = Collections.emptyMap();
+
+    public boolean getOrDefault(final String toggleId) {
+        return ref.getOrDefault(toggleId, false);
+    }
+
+    public void replaceAll(final Map<String, Boolean> newValues) {
+        ref = newValues;
+    }
+}

--- a/src/main/java/com/feature/toggle/mapchache/controller/MapCacheController.java
+++ b/src/main/java/com/feature/toggle/mapchache/controller/MapCacheController.java
@@ -1,0 +1,27 @@
+package com.feature.toggle.mapchache.controller;
+
+import com.feature.toggle.mapchache.service.MapCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/map/toggle")
+@RequiredArgsConstructor
+public class MapCacheController {
+
+    private final MapCacheService mapCacheService;
+
+    @GetMapping
+    public boolean isActive(@RequestParam final String toggleId) {
+        return mapCacheService.isActive(toggleId);
+    }
+
+    @PutMapping
+    public void changeUseYn(@RequestParam final String toggleId) {
+        mapCacheService.changeUseYn(toggleId);
+    }
+}

--- a/src/main/java/com/feature/toggle/mapchache/service/MapCacheService.java
+++ b/src/main/java/com/feature/toggle/mapchache/service/MapCacheService.java
@@ -1,0 +1,32 @@
+package com.feature.toggle.mapchache.service;
+
+import com.feature.toggle.mapchache.MapCacheToggleFinder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MapCacheService {
+    private final MapCacheToggleFinder mapCacheToggleFinder;
+
+    @Transactional
+    public void changeUseYn(final String toggleId) {
+        mapCacheToggleFinder.update(toggleId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isActive(final String toggleId) {
+        final boolean toggle = mapCacheToggleFinder.isActive(toggleId);
+
+        if (toggle) {
+            log.info("!! TRUE");
+        } else {
+            log.info("FALSE !!");
+        }
+
+        return toggle;
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -7,3 +7,10 @@ values ('TOGGLE-ONE', '유효기간이 지났지만 사용여부는 Y인 토글'
        ('TOGGLE-TWO', '유효기간이 지나고 사용하지 않는 토글', '2024-01-01 00:00:00', '2024-01-01 23:59:59', 'N'),
        ('TOGGLE-THREE', '유효기간에 해당하면서 사용 중인 토글', '2024-08-18 00:00:00', '2024-08-18 23:59:59', 'Y'),
        ('TOGGLE-FOUR', '유효기간이지만 사용하지 않는 토글', '2024-08-18 00:00:00', '2024-08-18 23:59:59', 'N');
+
+insert into SIMPLE_CACHE_TOGGLE_INFO (TOGGLE_ID, DESCRIPTION, USE_YN)
+values ('SIMPLE-CACHE-TOGGLE', '심플 토글입니다.', 'Y');
+
+insert into MAP_CACHE_TOGGLE_INFO (TOGGLE_ID, DESCRIPTION, USE_YN)
+values ('MAP-TOGGLE-ONE', '사용중인 심플 토글입니다.', 'Y'),
+       ('MAP-TOGGLE-TWO', '비사용중인 심플 토글입니다.', 'N');


### PR DESCRIPTION
EHCache를 이용하지 않고 직접 map을 이용한 localcache를 구현한 방식입니다.

이유로는, 스케줄러를 통해 DB에서 읽어온 토글의 값을 
완벽하게 변경해주시 위한 방식으로 구성하였습니다.